### PR TITLE
fixing service builder custom methods overloading

### DIFF
--- a/boilerplate/builders/service.js
+++ b/boilerplate/builders/service.js
@@ -25,9 +25,7 @@ export default class Service {
 
     if ( typeof options.custom == 'object' ) {
       for ( let name in options.custom ) {
-        if ( typeof options.custom[name] == 'function' ) {
-          this[name] = options.custom[name]
-        }
+        this[name] = options.custom[name]
       }
     }
 


### PR DESCRIPTION
As it stands there is no way of disabling default endpoints, therefore causing internal error on auth.